### PR TITLE
Added transaction reference to periodic payment request

### DIFF
--- a/src/SecurePay/Messages/PeriodicMessages.cs
+++ b/src/SecurePay/Messages/PeriodicMessages.cs
@@ -79,6 +79,9 @@ namespace SecurePay.Messages
         [XmlElement("txnID")]
         public string TransactionId;
 
+        [XmlElement("transactionReference")]
+        public string TransactionReference;
+
         [XmlElement("receipt")] 
         public string Receipt;
 

--- a/src/SecurePay/Model/TriggerPaymentRequest.cs
+++ b/src/SecurePay/Model/TriggerPaymentRequest.cs
@@ -3,5 +3,6 @@
     public class TriggerPaymentRequest : PeriodicRequest
     {
         public int? Amount;
+        public string TransactionReference { get; set; }
     }
 }

--- a/src/SecurePay/PeriodicClient.cs
+++ b/src/SecurePay/PeriodicClient.cs
@@ -74,7 +74,8 @@ namespace SecurePay
             var periodicItem = requestMessage.Periodic.PeriodicList.PeriodicItem;
             periodicItem.ActionType = "trigger";
             periodicItem.ClientId = request.ClientId;
-
+            periodicItem.Amount = request.Amount;
+            periodicItem.TransactionReference = request.TransactionReference;
             var responseMessage = await PostAsync<PeriodicRequestMessage, PeriodicResponseMessage>(requestMessage);
             periodicItem = responseMessage.Periodic.PeriodicList.PeriodicItem;
 


### PR DESCRIPTION
To be able to make a refund on a periodic payment, the original transaction reference needs to be supplied.